### PR TITLE
fix ScalarDB 3.17.1 driver integration and XLSX export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ $RECYCLE.BIN/
 
 # Mac crap
 .DS_Store
+
+# ScalarDB migration documentation
+docs/scalardb-3.17.1-migration-errors-and-fixes.md

--- a/plugins/org.jkiss.dbeaver.data.office/src/org/jkiss/dbeaver/data/office/export/DataExporterXLSX.java
+++ b/plugins/org.jkiss.dbeaver.data.office/src/org/jkiss/dbeaver/data/office/export/DataExporterXLSX.java
@@ -543,7 +543,8 @@ public class DataExporterXLSX extends StreamExporterAbstract implements IAppenda
 
             if (bg != null) {
                 // Setting the foreground color sets the background color. Is this a bug/feature of POI?
-                final XSSFCellStyle style = (XSSFCellStyle) this.style.clone();
+                final XSSFCellStyle style = (XSSFCellStyle) wb.createCellStyle();
+                style.cloneStyleFrom(this.style);
                 style.setFillForegroundColor(new XSSFColor(asColor(bg), new DefaultIndexedColorMap()));
                 style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
 

--- a/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
+++ b/plugins/org.jkiss.dbeaver.ext.generic/plugin.xml
@@ -1736,7 +1736,9 @@
                         defaultPort=""
                         description="ScalarDB JDBC driver"
                         webURL="https://scalardb.scalar-labs.com/docs/latest/scalardb-sql/jdbc-guide/">
-                    <file type="jar" path="maven:/com.scalar-labs:scalardb-sql-jdbc:4.0.0-SNAPSHOT" bundle="!drivers.scalardb"/>
+                    <file type="jar" path="maven:/com.google.guava:guava:32.1.3-jre" bundle="!drivers.scalardb"/>
+                    <file type="jar" path="maven:/com.scalar-labs:scalardb-sql-jdbc:3.17.1" bundle="!drivers.scalardb"/>
+                    <file type="jar" path="maven:/com.scalar-labs:scalardb-cluster-java-client-sdk:3.17.1" bundle="!drivers.scalardb"/>
                     <file type="jar" path="drivers/scalardb" bundle="drivers.scalardb"/>
                 </driver>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <local-p2-repo.url>https://p2.dev.dbeaver.com/eclipse-repo/</local-p2-repo.url>
+        <local-p2-repo.url>https://repo.dbeaver.net/p2/ce/23.2.5/</local-p2-repo.url>
         <eclipse-p2-repo.url>https://download.eclipse.org/releases/${eclipse-version}/</eclipse-p2-repo.url>
         <!-- Orbit deps. We need it for CB at least -->
         <orbit-repo.url>https://download.eclipse.org/tools/orbit/downloads/drops/R20221123021534/repository/</orbit-repo.url>
@@ -37,7 +37,7 @@
     <repositories>
         <repository>
             <id>local-contrib</id>
-            <url>${local-p2-repo.url}</url>
+            <url>https://repo.dbeaver.net/p2/ce/23.2.5/</url>
             <layout>p2</layout>
         </repository>
         <repository>


### PR DESCRIPTION
Summary

Fix ScalarDB 3.17.1 driver integration issues including Guava dependency conflict and XLSX export cell style cloning.

Issues Fixed

1. Connection Mode Implementation Not Found

Error:
DB-SQL-10017: No connection mode implementations are found. Please add a connection mode implementation to the classpath
java.lang.IllegalArgumentException: DB-SQL-10017: No connection mode implementations are found.
at com.scalar.db.sql.SqlTransactionFactory.getSqlTransactionProvider(SqlTransactionFactory.java:79)
at com.scalar.db.sql.SqlTransactionFactory.createSqlTransactionManager(SqlTransactionFactory.java:59)

Fix: Add scalardb-cluster-java-client-sdk:3.17.1 per https://scalardb.scalar-labs.com/docs/latest/scalardb-sql/jdbc-guide#add-scalardb-jdbc-driver-to-your-project.

2. Guava NoSuchMethodError (murmur3_32_fixed)

Error:
java.lang.NoSuchMethodError: 'com.google.common.hash.HashFunction com.google.common.hash.Hashing.murmur3_32_fixed()'
at com.scalar.db.cluster.common.ConsistentHashingDistribution.hash(ConsistentHashingDistribution.java:70)
at com.scalar.db.cluster.common.ConsistentHashingDistribution$VNode.hashCode(ConsistentHashingDistribution.java:97)

Root Cause: ScalarDB's transitive dependencies bring in older Guava versions:
- com.google.inject:guice:5.1.0 → guava:30.1-jre
- org.apache.cassandra:cassandra-driver-core:3.12.1 → guava:19.0

These versions don't have murmur3_32_fixed() (added in Guava 31.0).

Fix: Declare guava:32.1.3-jre as the first dependency in plugin.xml so the classloader loads it before transitive dependencies.

3. POI Cell Style Clone Error

Error:
[ERROR] The method clone() from the type Object is not visible
final XSSFCellStyle style = (XSSFCellStyle) this.style.clone();

Fix: Use wb.createCellStyle() + cloneStyleFrom() instead of clone().

4. P2 Repository URL Error

Error:
Unknown host p2.dev.dbeaver.com

Fix: Update URL to https://repo.dbeaver.net/p2/ce/23.2.5/

Changes
┌───────────────────────┬───────────────────────────────────────────────────────────┐
│         File          │                          Change                           │
├───────────────────────┼───────────────────────────────────────────────────────────┤
│ plugin.xml            │ Declare Guava first, add scalardb-cluster-java-client-sdk │
├───────────────────────┼───────────────────────────────────────────────────────────┤
│ DataExporterXLSX.java │ Fix cell style cloning                                    │
├───────────────────────┼───────────────────────────────────────────────────────────┤
│ pom.xml               │ Update P2 repository URL                                  │
├───────────────────────┼───────────────────────────────────────────────────────────┤
│ .gitignore            │ Exclude local documentation                               │
└───────────────────────┴───────────────────────────────────────────────────────────┘
Test Plan

- Build succeeds with mvn clean install -DskipTests
- ScalarDB connection works without Guava error
- Driver downloads dependencies correctly
